### PR TITLE
Remove assignment type hints to be python 3.5 compatible

### DIFF
--- a/traze/adapter.py
+++ b/traze/adapter.py
@@ -18,8 +18,8 @@ class TrazeMqttAdapter:
 
         self.connected = False
 
-        self.__client_id__:str = str(uuid.uuid4())
-        self._client:mqtt.Client = mqtt.Client(client_id = self.__client_id__, transport=transport)
+        self.__client_id__ = str(uuid.uuid4())
+        self._client = mqtt.Client(client_id = self.__client_id__, transport=transport)
         self._client.on_connect = _on_connect
         self._client.tls_set_context()
         self._client.connect(host, port)

--- a/traze/bot.py
+++ b/traze/bot.py
@@ -50,7 +50,7 @@ class BotBase(Player, metaclass=ABCMeta):
     @property
     def actions(self) -> Set[Action]:
         # print("# actions at", self.x, self.y)
-        validActions:Set[Action] = set()
+        validActions = set()
         for action in list(Action):
             if self.valid(self.x + action.dX, self.y + action.dY):
                 validActions.add(action)

--- a/traze/client.py
+++ b/traze/client.py
@@ -52,10 +52,10 @@ class Grid(Base):
 class Player(Base):
     def __init__(self, game:'Game', name:str):
         super().__init__(game, name=name)
-        self._alive:bool = False
+        self._alive = False
         self._x, self._y = [-1, -1]
-        self._id:int = None
-        self._secret:str = ''
+        self._id = None
+        self._secret = ''
         self._last = [self._x, self._y]
 
     def join(self, on_update:Callable[[None], None]=None) -> 'Player':
@@ -135,12 +135,12 @@ class Player(Base):
         self.adapter.publish_steer(self.game.name, self._id, self._secret, course)
 
     def bail(self):
-        self._alive:bool = False
+        self._alive = False
         self.adapter.publish_bail(self.game.name, self._id, self._secret)
 
         self._x, self._y = [-1, -1]
-        self._id:int = None
-        self._secret:str = ''
+        self._id = None
+        self._secret = ''
 
     def __str__(self):
         return "%s(name=%s, id=%s, x=%d, y=%d)" % (self.__class__.__name__, self.name, self._id, self._x, self._y)
@@ -148,7 +148,7 @@ class Player(Base):
 class Game(Base):
     def __init__(self, world:'World', name:str):
         super().__init__(world, name=name)
-        self._grid:Grid = Grid(self).join()
+        self._grid = Grid(self).join()
 
     @property
     def world(self) -> 'World':
@@ -162,7 +162,7 @@ class World(Base):
     def __init__(self, adapter=TrazeMqttAdapter()):
         super().__init__()
         self.__adapter__ = adapter
-        self.__games__:Dict[Game] = dict()
+        self.__games__ = dict()
 
         def add_game(name:str):
             if name not in self.__games__:

--- a/traze/topic.py
+++ b/traze/topic.py
@@ -23,7 +23,7 @@ class MqttTopic:
 
     def subscribe(self, on_payload_func: Callable[[object], None]):
         def on_message(client, userdata, message: MQTTMessage):
-            payload:object = json.loads(str(message.payload, 'utf-8'))
+            payload = json.loads(str(message.payload, 'utf-8'))
             for on_payload in self.functions:
                 # print("  call %s at %s" % (on_payload, self._name))
                 on_payload(payload)


### PR DESCRIPTION
Lots of systems, including debian and raspbian, are providing python 3.5 as default.
Type-hints for assigning local variables were added in python 3.6, making the library unusable with python < 3.6.
It would be nice to go without these two type hints and be compatible to more systems instead.