### PR TITLE
Avoid determining the wrong "alive" state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .vscode/
 
 *.egg-info/
+*.pyc

--- a/traze/client.py
+++ b/traze/client.py
@@ -60,7 +60,7 @@ class Player(Base):
         super().__init__(game, name=name)
         self._alive = False
         self._x, self._y = [-1, -1]
-        self._id = None
+        self._id = -1
         self._secret = ''
         self._last = [self._x, self._y]
 
@@ -73,11 +73,9 @@ class Player(Base):
             on_update()
 
         def on_players(payload):
-            alive = False
-            for player in payload:
-                if (player['id'] == self._id):
-                    alive = True
-                    break
+            alive = self._id >= 0 and any((True for player in payload if player["id"] == self._id))
+            if not alive:
+                self._id = -1
             self._alive = alive
 
         def on_grid(payload):


### PR DESCRIPTION
The traze gameserver reassigns player IDs.
Consider the following situation:
* I join and get the player ID 5
* I die
* Another player joins (player ID 5)
* I join (player ID 6)

As the code didn't reset the player ID, the "alive" state would be true as soon as the other player joins.
That prevented the actual client to rejoin the game, since it's assumed to be still alive.

The code below fixes this behavior.